### PR TITLE
Three small fixes: API v13, volume_resize units, filesystem_path wantarray

### DIFF
--- a/MooseFSPlugin.pm
+++ b/MooseFSPlugin.pm
@@ -1021,7 +1021,7 @@ sub volume_resize {
         Carp::confess("[${\__PACKAGE__}::$0] called with invalid volname: " . (defined $volname ? ref($volname) : 'undef'));
     }
 
-    log_debug "[volume_resize] Resizing $volname to $size KiB";
+    log_debug "[volume_resize] Resizing $volname to $size bytes";
 
     # Defensive - make sure $scfg is a hashref, not a storeid
     $scfg = PVE::Storage::config()->{ids}->{$storeid} unless ref($scfg) eq 'HASH';
@@ -1041,7 +1041,8 @@ sub volume_resize {
 
     log_debug "[volume_resize] Resizing mfsbdev volume: $mfs_path";
 
-    my $size_bytes = $size * 1024;  # Convert KiB to bytes
+    # PVE passes $size in bytes to volume_resize (not KiB).
+    my $size_bytes = $size;
 
     # Step 1: Check if volume is currently mapped and unmap it
     my $was_mapped = 0;

--- a/MooseFSPlugin.pm
+++ b/MooseFSPlugin.pm
@@ -220,7 +220,7 @@ sub moosefs_unmount {
 }
 
 sub api {
-    return 12;
+    return 13;
 }
 
 sub type {

--- a/MooseFSPlugin.pm
+++ b/MooseFSPlugin.pm
@@ -828,7 +828,8 @@ sub path {
     # FIX #51: TPM state files require special handling - they must be directory paths
     # Windows TPM expects specific file:// protocol paths that must be absolute
     if (defined $volname && $volname =~ /tpm/i) {
-        my $tpm_path = $class->filesystem_path($scfg, $volname, $snapname);
+        my ($tpm_path, $tpm_vmid, $tpm_vtype) =
+            $class->filesystem_path($scfg, $volname, $snapname);
 
         # For TPM state files, ensure the directory exists with proper permissions
         if ($tpm_path && $tpm_path =~ /tpmstate/) {
@@ -849,7 +850,7 @@ sub path {
             log_debug "[path] TPM state path resolved to: $tpm_path";
         }
 
-        return $tpm_path;
+        return wantarray ? ($tpm_path, $tpm_vmid, $tpm_vtype) : $tpm_path;
     }
 
     # fallback to default if bdev not enabled
@@ -938,7 +939,8 @@ sub filesystem_path {
     # Skip NBD mapping for TPM state volumes - they need direct filesystem paths (directories)
     if ($name && $name =~ /^vm-\d+-tpmstate/) {
         log_debug "[filesystem_path] Returning direct path for TPM state volume $volname";
-        return "$scfg->{path}/images/$vmid/$name";
+        my $tpm_path = "$scfg->{path}/images/$vmid/$name";
+        return wantarray ? ($tpm_path, $vmid, $vtype) : $tpm_path;
     }
 
     # Handle snapshots for raw format in MooseFS
@@ -946,7 +948,8 @@ sub filesystem_path {
         # MooseFS supports snapshots for raw files through mfsmakesnapshot
         # Return the path to the snapshot file
         my $mountpoint = $scfg->{path};
-        return "$mountpoint/images/$vmid/snaps/$snapname/$name";
+        my $snap_path = "$mountpoint/images/$vmid/snaps/$snapname/$name";
+        return wantarray ? ($snap_path, $vmid, $vtype) : $snap_path;
     }
 
     # Only do NBD logic for raw images without snapshots
@@ -976,11 +979,12 @@ sub filesystem_path {
     if ($output =~ m|file:\s+\Q$path\E\s+;\s+device:\s+(/dev/nbd\d+)|) {
         my $nbd = $1;
         log_debug "[fs-path] Found mapped device: $nbd";
-        return $nbd;
+        return wantarray ? ($nbd, $vmid, $vtype) : $nbd;
     }
 
     log_debug "[fs-path] No mapped device found, falling back to $scfg->{path}$path";
-    return "$scfg->{path}$path";
+    my $fallback = "$scfg->{path}$path";
+    return wantarray ? ($fallback, $vmid, $vtype) : $fallback;
 }
 
 # Query mfsbdev for volume size by parsing 'mfsbdev list' output


### PR DESCRIPTION
Hi! Been running pve-moosefs on my cluster and worked through a handful of bugs while trying to stabilize things — saw your 2026 status update in #61, totally understand, hope the following is useful rather than noise.

This is the smallest, lowest-risk of a series of fixes I have staged. All three changes are effectively one-liners:

- **Closes #56** — bump `api()` to 13. Upstream PVE storage API is at 13 (APIAGE=4, so 9–13 compatible). v12→v13 is purely additive (optional `$hints` on activate/map, new optional `on_update_hook_full`), so no behavior change is required.
- **Closes #57** — `volume_resize` on mfsbdev storage multiplied `$size` by 1024 assuming KiB, but PVE passes bytes. Symptom: `pct resize +4G` turned an 8 GiB disk into 12 TiB. Matches the user report exactly.
- **Closes #55** — `filesystem_path` and the TPM branch in `path` didn't honor `wantarray`. List-context callers (including `pct fsck`) got `undef` for `$vmid`/`$vtype`, which is exactly why fsck gets an empty device-path argument in the issue.

## Bigger picture — rest of my fork

I have four more PRs staged on my fork that I'd love guidance on how to land. Quick summary:

- **[arki05#2](https://github.com/arki05/pve-moosefs/pull/2)** — per-storage `mfsbdev` daemon fixes (`moosefs_bdev_is_active` / `moosefs_start_bdev` didn't honor `mfsnbdlink`, so multi-storage setups collapsed onto one daemon) + propagate `$cache`/`$hints` to SUPER in `activate_volume`.
- **[arki05#3](https://github.com/arki05/pve-moosefs/pull/3)** — ships a systemd drop-in setting `KillMode=mixed` on `pvestatd`. **Closes #60** (pvestatd SIGKILLing mfsmount on restart). Touches packaging.
- **[arki05#4](https://github.com/arki05/pve-moosefs/pull/4)** — largest. Hardens the NBD lifecycle (`deactivate_volume` / `free_image` / `alloc_image` / `map_volume` / `volume_import`) to propagate errors and verify state instead of swallowing them. Addresses the chained bugs behind **#50** (move-volume corruption) and **#47** (live-migration reverts to FUSE).
- **[arki05#5](https://github.com/arki05/pve-moosefs/pull/5)** — NBD-safe snapshots. Adds `volume_qemu_snapshot_method => 'mixed'` + `rename_snapshot` with `"current"` support, plus a defensive guard in `with_nbd_unmapped`. **Closes #58**.

I also have an `integration/all-fixes` branch on the fork with all 9 logical fixes on top of main, in case you want to pull/test the whole bundle locally.

## Test status

Most of these are verified against a real PVE 9.1 cluster running 4 concurrent MooseFS storages with `mfsbdev` enabled. PR 5 (mixed snapshots) was tested end-to-end against a hand-crafted volume — snapshot / rename-to-current / delete all work through a staging module on the live cluster. What I can't test until my cluster frees up: live migration (#47), a real running-VM snapshot through the PVE UI (#5 end-to-end), and the `pvestatd` drop-in's effect through a real restart (#3). Happy to do those once the window is open.

## Question

How would you like the rest staged?
1. Open the remaining four against upstream separately, same shape as this one
2. One combined PR from `integration/all-fixes` — easier to merge, harder to review
3. Some subset now (e.g. trivia + packaging + per-storage-daemon) and the lifecycle/snapshot work later after more soak time

Happy to re-stage however you want. Thanks for pve-moosefs.